### PR TITLE
added parsing of source-filter in ST2022-6 SDP

### DIFF
--- a/src/grammar.cpp
+++ b/src/grammar.cpp
@@ -973,7 +973,22 @@ namespace sdptransform
 						// format:
 						"framerate:%s"
 					},
-
+					// a=source-filter: incl IN IP4 239.5.2.31 10.1.15.5
+					{
+						// name:
+						"sourceFilter",
+						// push:
+						"",
+						// reg:
+						std::regex("^source-filter:*(excl|incl) (\\S*) (IP4|IP6|\\*) (\\S*) (.*)"),
+						// names:
+						{"filterMode", "netType", "addressTypes", "destAddress", "srcList"},
+						// types:
+						{ 's', 's', 's', 's', 's' },
+						// format:
+						"source-filter: %s %s %s %s %s"
+					},
+					
 					// Any a= that we don't understand is kepts verbatim on media.invalid.
 					{
 						// name:

--- a/test/data/st2022-6.sdp
+++ b/test/data/st2022-6.sdp
@@ -1,0 +1,8 @@
+v=0
+o=- 198403 11 IN IP4 192.168.20.20
+s=st2022-6 source
+t=0 0
+m=video 2004 RTP/AVP 98
+c=IN IP4 239.0.0.1/32
+a=rtpmap:98 SMPTE2022-6/27000000
+a=source-filter: incl IN IP4 239.0.0.1 192.168.20.20

--- a/test/parse.test.cpp
+++ b/test/parse.test.cpp
@@ -819,15 +819,15 @@ SCENARIO("st2022-6Sdp", "[parse]")
 	REQUIRE(session.find("media") != session.end());
 	auto& media = session.at("media");
 
-  // no invalid node
+	// no invalid node
 	REQUIRE(media.find("invalid") == media.end())
 
-  // check sourceFilter node exists
+	// check sourceFilter node exists
 	auto& video = media[1];
 	REQUIRE(video.find("sourceFilter") != video.end());
 	auto& sourceFilter = video.at("sourceFilter");
 
-  // check expected values are present
+	// check expected values are present
 	REQUIRE(sourceFilter.at("filterMode") == "incl");
 	REQUIRE(sourceFilter.at("netType") == "IN");
 	REQUIRE(sourceFilter.at("addressTypes") == "IP4");

--- a/test/parse.test.cpp
+++ b/test/parse.test.cpp
@@ -808,3 +808,29 @@ SCENARIO("simulcastSdp", "[parse]")
 
 	REQUIRE(newSdp == sdp);
 }
+
+SCENARIO("st2022-6Sdp", "[parse]")
+{
+	auto sdp = helpers::readFile("test/data/st2022-6.sdp");
+	auto session = sdptransform::parse(sdp);
+
+	// session sanity check
+	REQUIRE(session.size() > 0);
+	REQUIRE(session.find("media") != session.end());
+	auto& media = session.at("media");
+
+  // no invalid node
+	REQUIRE(media.find("invalid") == media.end())
+
+  // check sourceFilter node exists
+	auto& video = media[1];
+	REQUIRE(video.find("sourceFilter") != video.end());
+	auto& sourceFilter = video.at("sourceFilter");
+
+  // check expected values are present
+	REQUIRE(sourceFilter.at("filterMode") == "incl");
+	REQUIRE(sourceFilter.at("netType") == "IN");
+	REQUIRE(sourceFilter.at("addressTypes") == "IP4");
+	REQUIRE(sourceFilter.at("destAddress") == "239.0.0.1");
+	REQUIRE(sourceFilter.at("srcList") == "192.168.20.20");
+}


### PR DESCRIPTION
grammar.cpp was missing an entry for "source-filter" as defined in RFC4570.

This PR is a port of https://github.com/clux/sdp-transform/pull/69