### PR TITLE
add aes67 tags and test scenario

### DIFF
--- a/doc/Grammar.md
+++ b/doc/Grammar.md
@@ -548,6 +548,32 @@ Old simulcast draft [revision 03](https://tools.ietf.org/html/draft-ietf-mmusic-
 * example: "25.0"
 
 
+### ts-refclk
+
+`a=ts-refclk:ptp=IEEE1588-2008:00-50-C2-FF-FE-90-04-37:0`
+
+* type: string
+* example: "ptp=IEEE1588-2008:00-1D-C1-FF-FE-12-00-A4:0"
+
+
+### mediaclk
+
+`a=mediaclk:direct=0`
+
+`a=mediaclk:sender`
+
+* type: string
+* example: "direct=0"
+
+
+### sync-time
+
+`a=sync-time:0`
+
+* type: integer
+* example: "0"
+
+
 ### invalid
 
 Unknown SDP lines are stored within the `invalid` key.

--- a/src/grammar.cpp
+++ b/src/grammar.cpp
@@ -989,6 +989,54 @@ namespace sdptransform
 						"source-filter: %s %s %s %s %s"
 					},
 
+					// a=ts-refclk: as in aes67
+					{
+						// name:
+						"ts-refclk",
+						// push:
+						"",
+						// reg:
+						std::regex("^ts-refclk:(.*)"),
+						// names:
+						{ },
+						// types:
+						{ 's' },
+						// format:
+						"ts-refclk:%s"
+					},
+
+					// a=mediaclk: as in aes67
+					{
+						// name:
+						"mediaclk",
+						// push:
+						"",
+						// reg:
+						std::regex("^mediaclk:(.*)"),
+						// names:
+						{ },
+						// types:
+						{ 's' },
+						// format:
+						"mediaclk:%s"
+					},
+
+					// a=sync-time: as in aes67
+					{
+						// name:
+						"sync-time",
+						// push:
+						"",
+						// reg:
+						std::regex("\\d"),
+						// names:
+						{ },
+						// types:
+						{ 'd' },
+						// format:
+						"sync-time:%d"
+					},
+
 					// Any a= that we don't understand is kepts verbatim on media.invalid.
 					{
 						// name:

--- a/test/data/aes67.sdp
+++ b/test/data/aes67.sdp
@@ -1,0 +1,13 @@
+v=0
+o=- 1 1 IN IP4 192.168.2.3
+s=from-xnode
+c=IN IP4 239.192.1.33/128
+t=0 0
+m=audio 5004 RTP/AVP 96
+a=rtpmap:96 L24/48000/2
+a=ptime:1
+a=maxptime:5
+a=recvonly
+a=ts-refclk:ptp=IEEE1588-2008:00-1D-C1-FF-FE-12-00-A4:0
+a=mediaclk:direct=0
+a=sync-time:0

--- a/test/parse.test.cpp
+++ b/test/parse.test.cpp
@@ -878,3 +878,32 @@ SCENARIO("st2110-20Sdp", "[parse]")
 		})"_json
 	);
 }
+
+SCENARIO("aes67", "[parse]")
+{
+	auto sdp = helpers::readFile("test/data/aes67.sdp");
+	auto session = sdptransform::parse(sdp);
+
+	REQUIRE(session.size() > 0);
+	REQUIRE(session.find("media") != session.end());
+
+	auto& media = session.at("media");
+	auto& audio = media[0];
+	auto audioPayloads = sdptransform::parsePayloads(audio.at("payloads"));
+
+	REQUIRE(audioPayloads == R"([ 96 ])"_json);
+
+	REQUIRE(audio.at("type") == "audio");
+	REQUIRE(audio.at("protocol") == "RTP/AVP");
+	REQUIRE(audio.at("rtp")[0].at("payload") == 96);
+	REQUIRE(audio.at("rtp")[0].at("codec") == "L24");
+	REQUIRE(audio.at("rtp")[0].at("rate") == 48000);
+	REQUIRE(audio.at("rtp")[0].at("encoding") == "2");
+	REQUIRE(audio.at("ts-refclk") == "ptp=IEEE1588-2008:00-1D-C1-FF-FE-12-00-A4:0");
+	REQUIRE(audio.at("mediaclk") == "direct=0");
+	REQUIRE(audio.at("sync-time") == 0);
+
+	auto newSdp = sdptransform::write(session);
+
+	REQUIRE(newSdp == sdp);
+}


### PR DESCRIPTION
Please add three new sdp tags to grammar.cpp. These are standard tags required for e.g. aes-67 and might be useful for other scenarios as well. 