### PR TITLE
Add optional ttl to connection ip parsing

### DIFF
--- a/doc/Grammar.md
+++ b/doc/Grammar.md
@@ -100,13 +100,17 @@ if (
 
 `c=IN IP4 10.47.197.26`
 
+`c=IN IP4 224.2.36.42/127`
+
 * type: object
 
 | field           | type    | example
 | --------------- | ------- | -------------------------
 | version         | integer | 4
 | ip              | string  | "10.47.197.26"
+| ttl             | integer | 15
 
+*NOTE:* `ttl` is just present in the object if `ip` is followed by `/` plus a number. More info in the [RFC 4566 section 5.7](https://tools.ietf.org/html/rfc4566#section-5.7).
 
 ### bandwidth
 

--- a/src/grammar.cpp
+++ b/src/grammar.cpp
@@ -226,13 +226,20 @@ namespace sdptransform
 						// push:
 						"",
 						// reg:
-						std::regex("^IN IP(\\d) (\\S*)"),
+						std::regex("^IN IP(\\d) ([^\\\\S/]*)(?:/(\\d*))?"),
 						// names:
-						{ "version", "ip" },
+						{ "version", "ip" , "ttl"},
 						// types:
-						{ 'd', 's' },
+						{ 'd', 's', 'd'},
 						// format:
-						"IN IP%d %s"
+						"",
+						// formatFunc:
+						[](const json& o)
+						{
+							return hasValue(o, "ttl")
+								? "IN IP%d %s/%d"
+								: "IN IP%d %s";
+						}
 					}
 				}
 			},


### PR DESCRIPTION
As described in RFC 4566 section 5.7, IPv4 multicast connection addresses must also include a TTL in addition to the address