### PR TITLE
Make tests opt-in via `-DSDPTRANSFORM_BUILD_TESTS=ON`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
 before_install:
 - eval "${MATRIX_EVAL}"
 install:
-- cmake . -Bbuild
+- cmake . -Bbuild -DSDPTRANSFORM_BUILD_TESTS=ON
 - cmake --build build
 script:
 - ${TRAVIS_BUILD_DIR}/build/test/test_sdptransform

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,17 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # For CMake < 3.1.
 add_compile_options(-std=c++11)
 
-subdirs(test readme-helper)
+option(SDPTRANSFORM_BUILD_TESTS "Build unit tests" OFF)
+
+message("\n=========== libsdptransform Build Configuration ===========\n")
+message(STATUS "SDPTRANSFORM_BUILD_TESTS : " ${SDPTRANSFORM_BUILD_TESTS})
+message("")
+
+if (${SDPTRANSFORM_BUILD_TESTS})
+	add_subdirectory(test)
+endif()
+
+add_subdirectory(readme-helper)
 
 include_directories(${sdptransform_SOURCE_DIR}/include)
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,7 +17,7 @@ if [ "$1" == "rebuild" ]; then
 	echo "[INFO] rebuilding CMake project: cmake . -Bbuild [...]"
 
 	rm -rf build/ bin/
-	cmake . -Bbuild
+	cmake . -Bbuild -DSDPTRANSFORM_BUILD_TESTS=ON
 
 	# Remove the 'rebuild' argument.
 	shift


### PR DESCRIPTION
This change makes test compilation opt-in (analog to how [libmediasoupclient](https://github.com/versatica/libmediasoupclient/blob/v3/CMakeLists.txt#L21) does it), 
resulting in a **consistent build-time reduction of ~60%**.

## Build with tests enabled

`time cmake . -Bbuild -DSDPTRANSFORM_BUILD_TESTS=ON`

```
Executed in  913.33 millis    fish           external
   usr time  410.18 millis  150.00 micros  410.02 millis
   sys time  391.09 millis  857.00 micros  390.23 millis
```

`time cmake --build build`

```
Executed in   21.44 secs    fish           external
   usr time   20.11 secs  143.00 micros   20.11 secs
   sys time    1.12 secs  970.00 micros    1.12 secs
```

---

## Build with tests disabled

`time cmake . -Bbuild -DSDPTRANSFORM_BUILD_TESTS=OFF`

```
Executed in  869.65 millis    fish           external
   usr time  419.19 millis  167.00 micros  419.02 millis
   sys time  378.94 millis  891.00 micros  378.05 millis
```

`time cmake --build build`

```
Executed in    8.85 secs    fish           external
   usr time    8.21 secs    0.20 millis    8.21 secs
   sys time    0.56 secs    1.52 millis    0.56 secs
```