### PR TITLE
Remove unnecessary regex

### DIFF
--- a/include/string_view.hpp
+++ b/include/string_view.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <regex>
+
+#if __cplusplus >= 201703L
+#include <string_view>
+namespace sdptransform {
+    using string_view=std::string_view;
+    string_view convertMatchToView(const std::ssub_match& match) {
+        #if __cplusplus >= 202002L && __cpp_lib_concepts
+        return string_view(match.first, match.second);
+        #else
+        return string_view(&(*match.first), match.second-match.first);
+        #endif
+    }
+}
+#else
+#include <string_view_lite.hpp>
+namespace sdptransform {
+    using string_view=string_view_lite;
+    string_view convertMatchToView(const std::ssub_match& match) {
+        return string_view(match.first, match.second);
+    }
+}
+#endif

--- a/include/string_view_lite.hpp
+++ b/include/string_view_lite.hpp
@@ -1,0 +1,190 @@
+#pragma once
+
+#include <string>
+#include <algorithm>
+#include <ostream>
+
+namespace sdptransform
+{
+    // lite version of string_view for c++14
+    class string_view_lite
+    {
+    public:
+        // types
+        using Traits_type = std::char_traits<char>;
+        using value_type = char;
+        using pointer = value_type *;
+        using const_pointer = const value_type *;
+        using reference = value_type &;
+        using const_reference = const value_type &;
+        using const_iterator = const value_type *;
+        using iterator = const_iterator;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+        using reverse_iterator = const_reverse_iterator;
+        using size_type = size_t;
+        using difference_type = ptrdiff_t;
+        static constexpr size_type npos = size_type(-1);
+
+        constexpr string_view_lite() noexcept {}
+        constexpr string_view_lite(const string_view_lite &) noexcept = default;
+        constexpr string_view_lite &operator=(const string_view_lite &) noexcept = default;
+        string_view_lite(const value_type *str) : data_(str), size_(Traits_type::length(str)) {}
+        constexpr string_view_lite(std::nullptr_t) = delete;
+        string_view_lite(const value_type *str, size_type len) : data_(str), size_(len)
+        {
+            if (Traits_type::length(str) < size_)
+            {
+                throw std::runtime_error("string_view_lite constructor : wrong length");
+            }
+        }
+        string_view_lite(std::string::const_iterator begin, std::string::const_iterator end) : data_(&(*begin)), size_(end - begin) {}
+        string_view_lite(const std::string &s) : data_(s.data()), size_(s.size()) {}
+
+        // iterator support
+        constexpr const_iterator begin() const noexcept { return data_; }
+        constexpr const_iterator end() const noexcept { return data_ + size_; }
+        constexpr const_iterator cbegin() const noexcept { return begin(); }
+        constexpr const_iterator cend() const noexcept { return end(); }
+        const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
+        const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
+        const_reverse_iterator crbegin() const noexcept { return rbegin(); }
+        const_reverse_iterator crend() const noexcept { return rend(); }
+
+        // capacity
+        constexpr size_type size() const noexcept { return size_; }
+        constexpr size_type length() const noexcept { return size(); }
+        constexpr size_type max_size() const noexcept { return npos; }
+        [[nodiscard]] constexpr bool empty() const noexcept
+        {
+            return size() == 0U;
+        }
+
+        // element access
+        constexpr const_reference operator[](size_type pos) const { return *(data_ + pos); }
+        constexpr const_reference at(size_type pos) const
+        {
+            if (pos >= size_)
+            {
+                throw std::out_of_range("string_view_lite at");
+            }
+            return operator[](pos);
+        }
+        constexpr const_reference front() const
+        {
+            if (empty())
+            {
+                throw std::out_of_range("string_view_lite front");
+            }
+            return *begin();
+        }
+        constexpr const_reference back() const
+        {
+            if (empty())
+            {
+                throw std::out_of_range("string_view_lite back");
+            }
+            return *(end() - 1);
+        }
+        constexpr const_pointer data() const noexcept { return data_; }
+
+        // modifiers
+        constexpr void remove_prefix(size_type n)
+        {
+            if (n >= size_)
+            {
+                string_view_lite sv;
+                swap(sv);
+            }
+            else
+            {
+                data_ += n;
+                size_ -= n;
+            }
+        }
+        constexpr void remove_suffix(size_type n)
+        {
+            if (n >= size_)
+            {
+                string_view_lite sv;
+                swap(sv);
+            }
+            else
+            {
+                size_ -= n;
+            }
+        }
+        void swap(string_view_lite &s) noexcept
+        {
+            std::swap(data_, s.data_);
+            std::swap(size_, s.size_);
+        }
+
+        // string operations
+
+        string_view_lite substr(size_type pos = 0, size_type n = npos) const
+        {
+            if (pos > size_)
+            {
+                throw std::out_of_range("string_view_lite substr");
+            }
+            if (pos == size_)
+            {
+                return string_view_lite();
+            }
+            if (n == npos || size_ < (n + pos))
+            {
+                return string_view_lite(data_ + pos, size_ - pos);
+            }
+            return string_view_lite(data_ + pos, n);
+        }
+
+        // searching
+        constexpr size_type find(string_view_lite s, size_type pos = 0) const noexcept
+        {
+            return pos >= size() ? npos : std::search(cbegin() + pos, cend(), s.cbegin(), s.cend(), Traits_type::eq) - cbegin();
+        }
+        constexpr size_type find(value_type c, size_type pos = 0) const noexcept
+        {
+            return (empty() || pos >= size()) ? npos : std::find(cbegin() + pos, cend(), c) - cbegin();
+        }
+
+        constexpr size_type find_first_of(value_type c, size_type pos = 0) const noexcept
+        {
+            return find(c, pos);
+        }
+        size_type find_last_of(value_type c, size_type pos = npos) const noexcept
+        {
+            return empty() ? npos : std::find(const_reverse_iterator(cbegin() + pos + 1), crend(), c) - crbegin();
+        }
+        constexpr size_type find_first_not_of(value_type c, size_type pos = 0) const noexcept
+        {
+            return (pos >= size() || empty())
+                       ? npos
+                       : std::find_if(cbegin() + pos, cend(), [&c](char other)
+                                      { return other != c; }) -
+                             cbegin();
+        }
+        constexpr size_type find_last_not_of(value_type c, size_type pos = npos) const noexcept
+        {
+            return empty() ? npos : std::find_if(const_reverse_iterator(cbegin() + pos + 1), crend(), [&c](char other)
+                                                 { return other != c; }) -
+                                        crbegin();
+        }
+
+    private:
+        const_pointer data_ = ""; // exposition only
+        size_type size_ = 0U;     // exposition only
+    };
+
+    std::basic_ostream<string_view_lite::value_type, string_view_lite::Traits_type> &
+    operator<<(std::basic_ostream<string_view_lite::value_type, string_view_lite::Traits_type> &os,
+               string_view_lite str)
+    {
+        for (char c : str)
+        {
+            os << c;
+        }
+        return os;
+    }
+
+} // namespace sdptransform

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -34,8 +34,6 @@ namespace sdptransform
 
 	json parse(const std::string& sdp)
 	{
-		static const std::regex ValidLineRegex("^([a-z])=(.*)");
-
 		json session = json::object();
 		std::stringstream sdpstream(sdp);
 		std::string line;
@@ -49,7 +47,8 @@ namespace sdptransform
 				line.pop_back();
 
 			// Ensure it's a valid SDP line.
-			if (!std::regex_search(line, ValidLineRegex))
+			// we match ^[a-z]=
+			if (line.size()<2 || line[0]<'a' || line[0] > 'z' || line[1]!='=')
 				continue;
 
 			char type = line[0];

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -2,6 +2,7 @@
 #include <cstddef>   // size_t
 #include <sstream>   // std::stringstream
 #include <stdexcept>
+#include "string_view.hpp"
 
 namespace sdptransform
 {
@@ -166,42 +167,52 @@ namespace sdptransform
 
 		linestream << type << "=";
 
+		string_view runningFormat(format);
+		size_t nextPos = 0U;
 		for(
-			auto it = std::sregex_iterator(format.begin(), format.end(), FormatRegex);
-			it != std::sregex_iterator();
-		  ++it
-		 )
+			auto pos = runningFormat.find('%'); pos != std::string::npos; pos = runningFormat.find('%',nextPos))
 		{
-			const std::smatch& match = *it;
-			const std::string& str = match.str();
+			const char nextChar = (pos+1<runningFormat.size()) ? runningFormat[pos+1] : '0';
+			const string_view prefix = runningFormat.substr(0,pos);
+
+			if(nextChar != '%' && nextChar != 'v' && nextChar != 'd' && nextChar != 's') {
+				nextPos = pos +2;
+				continue;
+			}
 
 			if (i >= len)
 			{
-				linestream << str;
+				linestream << prefix << '%' << nextChar;
 			}
 			else
 			{
 				auto& arg = args[i];
 				i++;
 
-				linestream << match.prefix();
+				linestream << prefix;
 
-				if (str == "%%")
+				if (nextChar == '%')
 				{
 					linestream << "%";
 				}
-				else if (str == "%s" || str == "%d")
+				else if (nextChar == 's' || nextChar == 'd')
 				{
 					if (arg.is_string())
 						linestream << arg.get<std::string>();
 					else
 						linestream << arg;
 				}
-				else if (str == "%v")
+				else if (nextChar == 'v')
 				{
 					// Do nothing.
 				}
 			}
+
+			runningFormat=runningFormat.substr(pos+2);
+			nextPos=0;
+		}
+		if(!runningFormat.empty()) {
+			linestream << runningFormat;
 		}
 
 		linestream << "\r\n";


### PR DESCRIPTION
I replace regex by charcter matching or string_view manipulation.
As we are not c++17 yet in the repo, I added a light version string_view to allow to work with it.

Next commit will be on the parser part with change for regex to speed-up find of correct regex