### PR TITLE
Expanded accepted "source-filter" grammar

### DIFF
--- a/src/grammar.cpp
+++ b/src/grammar.cpp
@@ -1013,7 +1013,7 @@ namespace sdptransform
 						// push:
 						"",
 						// reg:
-						std::regex("^source-filter:[\\s\\t]+(excl|incl) (\\S*) (IP4|IP6|\\*) (\\S*) (.*)"),
+						std::regex("^source-filter:[\\s\\t]*(excl|incl) (\\S*) (IP4|IP6|\\*) (\\S*) (.*)"),
 						// names:
 						{ "filterMode", "netType", "addressTypes", "destAddress", "srcList" },
 						// types:


### PR DESCRIPTION
The sdp "source-filter" attribute will now also accept the situation where there is no space after colons (i.e. "source-filter:excl" is accepted whereas before only "source-filter: excl" was acceptable).